### PR TITLE
Fix breakpoint asserts

### DIFF
--- a/BIDebugEngine/BIDebugEngine/Debugger.cpp
+++ b/BIDebugEngine/BIDebugEngine/Debugger.cpp
@@ -454,8 +454,11 @@ void Debugger::checkForBreakpoint(DebuggerInstructionInfo& instructionInfo) {
     if (doBreeak && instructionInfo.instruction->sdp.sourcefile.find("dedmen\\") != std::string::npos) __debugbreak();
     auto space = instructionInfo.instruction->sdp.sourcefile.find("[");
     auto properPath = (space != std::string::npos) ? instructionInfo.instruction->sdp.sourcefile.substr(0, space-1) : instructionInfo.instruction->sdp.sourcefile;
-    auto& found = breakPoints.get(properPath);
-    if (breakPoints.is_null(found) || found.empty()) return;
+    auto foundItr = breakPoints.find(properPath);
+
+    if (foundItr == breakPoints.end() || foundItr->second.empty()) return;
+
+    const auto& found = foundItr->second;
 
     std::vector<BreakPoint> BPsToTrigger;
     std::copy_if(found.begin(), found.end(), std::back_inserter(BPsToTrigger), [line = instructionInfo.instruction->sdp.sourceline](const BreakPoint& bp) {

--- a/BIDebugEngine/BIDebugEngine/Debugger.h
+++ b/BIDebugEngine/BIDebugEngine/Debugger.h
@@ -137,8 +137,8 @@ public:
         breakPointList& operator=(const breakPointList&) = delete;
     };
     std::shared_mutex breakPointsLock;
-    map_string_to_class<breakPointList, auto_array<breakPointList>> breakPoints; // All inputs have to be tolowered before accessing
-    //std::unordered_map<std::string, breakPointList> breakPoints; // All inputs have to be tolowered before accessing
+    //map_string_to_class<breakPointList, auto_array<breakPointList>> breakPoints; // All inputs have to be tolowered before accessing
+    std::unordered_map<r_string, breakPointList> breakPoints; // All inputs have to be tolowered before accessing
     std::vector<std::shared_ptr<IMonitorBase>> monitors;
     NetworkController nController;
     std::shared_ptr<std::pair<std::condition_variable, bool>> breakStateContinueEvent;

--- a/BIDebugEngine/BIDebugEngine/NetworkController.cpp
+++ b/BIDebugEngine/BIDebugEngine/NetworkController.cpp
@@ -69,8 +69,11 @@ void NetworkController::incomingMessage(const std::string& message) {
                 bp.Serialize(ar);
                 bp.filename.to_lower();
                 std::unique_lock<std::shared_mutex> lk(GlobalDebugger.breakPointsLock);
-                auto &bpVec = GlobalDebugger.breakPoints.get(bp.filename);
-                if (!GlobalDebugger.breakPoints.is_null(bpVec)) {
+                //auto &bpVec = GlobalDebugger.breakPoints.get(bp.filename.c_str());
+                //if (!GlobalDebugger.breakPoints.is_null(bpVec)) {
+                auto foundItr = GlobalDebugger.breakPoints.find(bp.filename);
+                if (foundItr != GlobalDebugger.breakPoints.end()) {
+                    auto& bpVec = foundItr->second;
                     auto vecFound = std::find_if(bpVec.begin(), bpVec.end(), [lineNumber = bp.line](const BreakPoint& bp) {
                         return lineNumber == bp.line;
                     });
@@ -80,8 +83,8 @@ void NetworkController::incomingMessage(const std::string& message) {
                     }
                     bpVec.push_back(std::move(bp));
                 } else {
-                    GlobalDebugger.breakPoints.insert(Debugger::breakPointList(std::move(bp)));
-                    //GlobalDebugger.breakPoints.emplace(std::string{bp.filename.c_str()}, std::move(bp));
+                    // GlobalDebugger.breakPoints.insert(Debugger::breakPointList(std::move(bp)));
+                    GlobalDebugger.breakPoints.emplace(bp.filename, std::move(bp));
                 }
             } break;
             case NC_CommandType::delBreakpoint: {
@@ -93,8 +96,11 @@ void NetworkController::incomingMessage(const std::string& message) {
                 fileName.to_lower();
                 //std::transform(fileName.begin(), fileName.end(), fileName.begin(), ::tolower);
                 std::unique_lock<std::shared_mutex> lk(GlobalDebugger.breakPointsLock);
-                auto &found = GlobalDebugger.breakPoints.get(fileName);
-                if (!GlobalDebugger.breakPoints.is_null(found)) {
+                //auto &found = GlobalDebugger.breakPoints.get(fileName.c_str());
+                //if (!GlobalDebugger.breakPoints.is_null(found)) {
+                auto foundItr = GlobalDebugger.breakPoints.find(fileName);
+                if (foundItr != GlobalDebugger.breakPoints.end()) {
+                    auto& found = foundItr->second;
                     auto vecFound = std::find_if(found.begin(), found.end(), [lineNumber](const BreakPoint& bp) {
                         return lineNumber == bp.line;
                     });
@@ -102,8 +108,8 @@ void NetworkController::incomingMessage(const std::string& message) {
                         found.erase(vecFound);
                     }
                     if (found.empty())
-                        //GlobalDebugger.breakPoints.erase(fileName);
-                        GlobalDebugger.breakPoints.remove(fileName);
+                        GlobalDebugger.breakPoints.erase(fileName);
+                        //GlobalDebugger.breakPoints.remove(fileName.c_str());
                 }
             } break;
             case NC_CommandType::BPContinue: {


### PR DESCRIPTION
This fixes the assert by replacing the hash map implementation for the breakpoints. It uses `r_string` so no copying.
Warning it contains everything in the other PR!